### PR TITLE
Add support for notes (and embeds in general)

### DIFF
--- a/src/Automerge.hs
+++ b/src/Automerge.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Automerge (parseAutomergeSpans, parseAutomergeSpansText, Span (..), BlockMarker (..), Heading (..), HeadingLevel (..), BlockSpan (..), BlockType (..), TextSpan (..), Mark (..), Link (..), toJSONText, takeUntilBlockSpan, takeUntilNextSameBlockTypeSibling, isTopLevelBlock, isParent, isSiblingListItem) where
+module Automerge (parseAutomergeSpans, parseAutomergeSpansText, Span (..), BlockMarker (..), Heading (..), HeadingLevel (..), NoteId (..), BlockSpan (..), BlockType (..), TextSpan (..), Mark (..), Link (..), toJSONText, takeUntilBlockSpan, takeUntilNextSameBlockTypeSibling, isTopLevelBlock, isParent, isSiblingListItem) where
 
 import Data.Aeson (FromJSON (parseJSON), Object, ToJSON (toJSON), Value (Bool, Null, String), eitherDecode, eitherDecodeStrictText, encode, object, withObject, withScientific, withText, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson.Key as K
@@ -50,10 +50,6 @@ instance FromJSON NoteId where
   parseJSON = withText "NoteId" $ \t -> do
     noteId <- parseNonEmpty "id" t
     pure $ NoteId noteId
-
-newtype NoteRef = NoteRef NoteId deriving (Show, Eq)
-
-newtype NoteContent = NoteContent NoteId deriving (Show, Eq)
 
 data BlockType
   = ParagraphType

--- a/src/Automerge.hs
+++ b/src/Automerge.hs
@@ -155,11 +155,11 @@ parseBlock v = do
     ImageType -> pure $ BlockSpan $ AutomergeBlock ImageBlockMarker parents isEmbed
     NoteRefType -> do
       attrs <- blockData .: "attrs"
-      noteId <- attrs .: "noteId"
+      noteId <- attrs .: "id"
       pure $ BlockSpan $ AutomergeBlock (NoteRefMarker noteId) parents isEmbed
     NoteContentType -> do
       attrs <- blockData .: "attrs"
-      noteId <- attrs .: "noteId"
+      noteId <- attrs .: "id"
       pure $ BlockSpan $ AutomergeBlock (NoteContentMarker noteId) parents isEmbed
 
 parseInline :: Object -> Parser Span

--- a/src/Automerge.hs
+++ b/src/Automerge.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Automerge (parseAutomergeSpans, parseAutomergeSpansText, Span (..), BlockMarker (..), Heading (..), HeadingLevel (..), NoteId (..), BlockSpan (..), BlockType (..), TextSpan (..), Mark (..), Link (..), toJSONText, takeUntilNonEmbedBlockSpan, takeUntilNextSameBlockTypeSibling, isTopLevelBlock, isParent, isSiblingListItem) where
+module Automerge (parseAutomergeSpans, parseAutomergeSpansText, Span (..), BlockMarker (..), Heading (..), HeadingLevel (..), NoteId (..), BlockSpan (..), BlockType (..), TextSpan (..), Mark (..), Link (..), toJSONText, isEmbed, takeUntilNonEmbedBlockSpan, takeUntilNextSameBlockTypeSibling, isTopLevelBlock, isParent, isSiblingListItem) where
 
 import Data.Aeson (FromJSON (parseJSON), Object, ToJSON (toJSON), Value (Bool, Null, String), eitherDecode, eitherDecodeStrictText, encode, object, withObject, withScientific, withText, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson.Key as K
@@ -321,6 +321,10 @@ takeUntilNextSameBlockTypeSibling bl (x : xs) = case x of
 
 isTopLevelBlock :: BlockSpan -> Bool
 isTopLevelBlock (AutomergeBlock _ parents _) = null parents
+
+isEmbed :: BlockSpan -> Bool
+isEmbed (AutomergeBlock _ _ True) = True
+isEmbed (AutomergeBlock _ _ False) = False
 
 isParent :: Maybe BlockSpan -> BlockSpan -> Bool
 isParent (Just block@(AutomergeBlock _ parents _)) (AutomergeBlock _ candidateParents _) = candidateLastParentMatches (blockType block) candidateParents && isProperPrefix parents candidateParents

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -90,6 +90,8 @@ getChildBlockSeeds blockSpan = addChildBlocks
   where
     addChildBlocks [] = []
     addChildBlocks (x : xs) = case x of
+      -- Note that we will enter this case even when `blockSpan` is `Nothing`.
+      -- In this case, `Automerge.isParent` will return true for the top-level blocks.
       Automerge.BlockSpan currentSpan | Automerge.isParent blockSpan currentSpan -> createChildBlockSeed currentSpan xs : addChildBlocks xs
       _ -> addChildBlocks xs
       where

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -70,7 +70,10 @@ buildTree :: [Automerge.Span] -> Maybe (Tree DocNode)
 buildTree = (fmap (traceTree . groupListItems . buildRawTree)) . nonEmpty
 
 buildRawTree :: NonEmpty Automerge.Span -> Tree DocNode
-buildRawTree spans = Node Root $ unfoldForest buildDocNode $ getChildBlockSeeds Nothing $ Data.List.NonEmpty.toList spans
+buildRawTree spans = Node Root $ unfoldForest buildDocNode $ getTopLevelBlockSeeds spansList
+  where
+    spansList = Data.List.NonEmpty.toList spans
+    getTopLevelBlockSeeds = getChildBlockSeeds Nothing
 
 buildDocNode :: (Automerge.Span, [Automerge.Span]) -> (DocNode, [(Automerge.Span, [Automerge.Span])])
 buildDocNode (currentSpan, remainingSpans) = case currentSpan of

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -190,8 +190,8 @@ replaceNoteRefsWithPandocNotes noteContentsMap = replaceNoteRefs
         Nothing ->
           -- Leave as an orphan ref; will be pruned later
           Node (BlockNode (NoteRef noteId)) []
-    -- Non-ref nodes remain the same
-    replaceNoteRefs node = node
+    -- Non-ref nodes remain the same. Call `replaceNoteRefs` recursively for their children.
+    replaceNoteRefs (Node node children) = Node node $ map replaceNoteRefs children
 
 pruneNonPandocNodeNotes :: Tree DocNode -> Tree DocNode
 pruneNonPandocNodeNotes (Node node children) = Node node prunedChildren

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -22,9 +22,9 @@ blocksToAutomergeSpans = concatMap $ blockToAutomergeSpans []
 blockToAutomergeSpans :: [Automerge.BlockType] -> Pandoc.Block -> [Automerge.Span]
 blockToAutomergeSpans parentBlockTypes block = case block of
   Pandoc.Plain inlines -> Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines
-  Pandoc.Para inlines -> (Automerge.BlockSpan $ AutomergeBlock ParagraphMarker parentBlockTypes) : (Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  Pandoc.Header level _ inlines -> (Automerge.BlockSpan $ AutomergeBlock (Automerge.HeadingMarker $ Heading $ HeadingLevel level) parentBlockTypes) : (Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  Pandoc.CodeBlock _ text -> [Automerge.BlockSpan $ AutomergeBlock Automerge.CodeBlockMarker parentBlockTypes, Automerge.TextSpan $ AutomergeText text []]
+  Pandoc.Para inlines -> (Automerge.BlockSpan $ AutomergeBlock ParagraphMarker parentBlockTypes False) : (Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines)
+  Pandoc.Header level _ inlines -> (Automerge.BlockSpan $ AutomergeBlock (Automerge.HeadingMarker $ Heading $ HeadingLevel level) parentBlockTypes False) : (Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines)
+  Pandoc.CodeBlock _ text -> [Automerge.BlockSpan $ AutomergeBlock Automerge.CodeBlockMarker parentBlockTypes False, Automerge.TextSpan $ AutomergeText text []]
   Pandoc.BulletList items -> concatMap (containerBlockToSpans parentBlockTypes BulletListItem) items
   Pandoc.OrderedList _ items -> concatMap (containerBlockToSpans parentBlockTypes OrderedListItem) items
   Pandoc.BlockQuote blocks -> (containerBlockToSpans parentBlockTypes PandocWriter.BlockQuote) blocks
@@ -34,9 +34,9 @@ containerBlockToSpans :: [Automerge.BlockType] -> ContainerBlockType -> [Pandoc.
 containerBlockToSpans parents itemType children = (containerBlockToSpan parents itemType : containerBlockChildrenToSpans parents itemType children)
   where
     containerBlockToSpan :: [Automerge.BlockType] -> ContainerBlockType -> Automerge.Span
-    containerBlockToSpan parentBlockTypes BulletListItem = Automerge.BlockSpan $ AutomergeBlock Automerge.UnorderedListItemMarker parentBlockTypes
-    containerBlockToSpan parentBlockTypes OrderedListItem = Automerge.BlockSpan $ AutomergeBlock Automerge.OrderedListItemMarker parentBlockTypes
-    containerBlockToSpan parentBlockTypes PandocWriter.BlockQuote = Automerge.BlockSpan $ AutomergeBlock Automerge.BlockQuoteMarker parentBlockTypes
+    containerBlockToSpan parentBlockTypes BulletListItem = Automerge.BlockSpan $ AutomergeBlock Automerge.UnorderedListItemMarker parentBlockTypes False
+    containerBlockToSpan parentBlockTypes OrderedListItem = Automerge.BlockSpan $ AutomergeBlock Automerge.OrderedListItemMarker parentBlockTypes False
+    containerBlockToSpan parentBlockTypes PandocWriter.BlockQuote = Automerge.BlockSpan $ AutomergeBlock Automerge.BlockQuoteMarker parentBlockTypes False
 
 containerBlockChildrenToSpans :: [Automerge.BlockType] -> ContainerBlockType -> [Pandoc.Block] -> [Automerge.Span]
 containerBlockChildrenToSpans parentBlockTypes itemType = concatMap $ blockToAutomergeSpans (parentBlockTypes <> [toAutomergeBlockType itemType])

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -57,9 +57,9 @@ blockToAutomergeSpans parentBlockTypes block = case block of
   _ -> return [] -- Ignore blocks we don't recognize
 
 containerBlockToSpans :: [Automerge.BlockType] -> ContainerBlockType -> [Pandoc.Block] -> NotesState [Automerge.Span]
-containerBlockToSpans parents itemType children = do
-  let containerSpan = containerBlockToSpan parents itemType
-  childSpans <- containerBlockChildrenToSpans parents itemType children
+containerBlockToSpans parentTypes itemType children = do
+  let containerSpan = containerBlockToSpan parentTypes itemType
+  childSpans <- containerBlockChildrenToSpans parentTypes itemType children
   return (containerSpan : childSpans)
   where
     containerBlockToSpan :: [Automerge.BlockType] -> ContainerBlockType -> Automerge.Span
@@ -71,10 +71,10 @@ containerBlockChildrenToSpans :: [Automerge.BlockType] -> ContainerBlockType -> 
 containerBlockChildrenToSpans parentBlockTypes itemType blocks = concat <$> mapM (blockToAutomergeSpans (parentBlockTypes <> [toAutomergeBlockType itemType])) blocks
 
 inlinesToAutomergeSpans :: [Automerge.BlockType] -> [Pandoc.Inline] -> NotesState [Automerge.Span]
-inlinesToAutomergeSpans parents inlines = mergeSameMarkSpans <$> concat <$> mapM (inlineToAutomergeSpans parents) inlines
+inlinesToAutomergeSpans parentTypes inlines = mergeSameMarkSpans <$> concat <$> mapM (inlineToAutomergeSpans parentTypes) inlines
 
 inlineToAutomergeSpans :: [Automerge.BlockType] -> Pandoc.Inline -> NotesState [Automerge.Span]
-inlineToAutomergeSpans parents inline = case inline of
+inlineToAutomergeSpans parentTypes inline = case inline of
   Pandoc.Note noteBlocks -> do
     -- Generate note ID and create note content
     state <- get
@@ -82,7 +82,7 @@ inlineToAutomergeSpans parents inline = case inline of
         noteIdText = T.pack $ show newNoteId
 
     -- Convert note blocks to spans
-    noteSpans <- blocksToAutomergeSpans parents noteBlocks
+    noteSpans <- blocksToAutomergeSpans parentTypes noteBlocks
     let noteContentSpan = Automerge.BlockSpan $ AutomergeBlock (NoteContentMarker $ Automerge.NoteId noteIdText) [] False
         allNoteSpans = noteContentSpan : noteSpans
 
@@ -96,13 +96,13 @@ inlineToAutomergeSpans parents inline = case inline of
     -- Return embedded note reference span
     return [Automerge.BlockSpan $ AutomergeBlock (NoteRefMarker $ Automerge.NoteId noteIdText) [] True]
   Pandoc.Strong inlines -> do
-    wrappedSpans <- inlinesToAutomergeSpans parents inlines
+    wrappedSpans <- inlinesToAutomergeSpans parentTypes inlines
     return $ addMark Automerge.Strong wrappedSpans
   Pandoc.Emph inlines -> do
-    wrappedSpans <- inlinesToAutomergeSpans parents inlines
+    wrappedSpans <- inlinesToAutomergeSpans parentTypes inlines
     return $ addMark Automerge.Emphasis wrappedSpans
   Pandoc.Link _ inlines (linkUrl, linkTitle) -> do
-    wrappedSpans <- inlinesToAutomergeSpans parents inlines
+    wrappedSpans <- inlinesToAutomergeSpans parentTypes inlines
     return $ addMark (Automerge.LinkMark $ Automerge.Link {url = linkUrl, title = linkTitle}) wrappedSpans
   _ -> return $ Automerge.TextSpan <$> inlineToTextSpan inline
 

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -34,13 +34,13 @@ blocksToAutomergeSpans parentBlockTypes blocks = concat <$> mapM (blockToAutomer
 
 blockToAutomergeSpans :: [Automerge.BlockType] -> Pandoc.Block -> NotesState [Automerge.Span]
 blockToAutomergeSpans parentBlockTypes block = case block of
-  Pandoc.Plain inlines -> inlinesToAutomergeSpans parentBlockTypes inlines
+  Pandoc.Plain inlines -> inlinesToAutomergeSpans (parentBlockTypes <> [ParagraphType]) inlines
   Pandoc.Para inlines -> do
-    inlineSpans <- inlinesToAutomergeSpans parentBlockTypes inlines
+    inlineSpans <- inlinesToAutomergeSpans (parentBlockTypes <> [ParagraphType]) inlines
     let blockSpan = Automerge.BlockSpan $ AutomergeBlock ParagraphMarker parentBlockTypes False
     return $ blockSpan : inlineSpans
   Pandoc.Header level _ inlines -> do
-    inlineSpans <- inlinesToAutomergeSpans parentBlockTypes inlines
+    inlineSpans <- inlinesToAutomergeSpans (parentBlockTypes <> [HeadingType]) inlines
     let blockSpan = Automerge.BlockSpan $ AutomergeBlock (Automerge.HeadingMarker $ Heading $ HeadingLevel level) parentBlockTypes False
     return $ blockSpan : inlineSpans
   Pandoc.CodeBlock _ text ->
@@ -97,7 +97,7 @@ inlineToAutomergeSpans parents inline = case inline of
       )
 
     -- Return embedded note reference span
-    return [Automerge.BlockSpan $ AutomergeBlock (NoteRefMarker $ Automerge.NoteId noteIdText) [] True]
+    return [Automerge.BlockSpan $ AutomergeBlock (NoteRefMarker $ Automerge.NoteId noteIdText) parents True]
   Pandoc.Strong inlines -> do
     wrappedSpans <- inlinesToAutomergeSpans parents inlines
     return $ addMark Automerge.Strong wrappedSpans

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -1,6 +1,7 @@
 module PandocWriter (writeAutomerge) where
 
-import Automerge (BlockMarker (..), BlockSpan (..), BlockType (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), Span (..), TextSpan (..), toJSONText)
+import Automerge (BlockMarker (..), BlockSpan (..), BlockType (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), NoteId (..), Span (..), TextSpan (..), toJSONText)
+import Control.Monad.State (State, get, modify, runState)
 import qualified Data.Text as T
 import Text.Pandoc (WriterOptions)
 import Text.Pandoc.Class (PandocMonad)
@@ -8,67 +9,126 @@ import Text.Pandoc.Definition as Pandoc (Block (..), Inline (..), Pandoc (Pandoc
 
 data ContainerBlockType = BulletListItem | OrderedListItem | BlockQuote deriving (Show, Eq)
 
+data NoteData = NoteData
+  { noteCounter :: Int,
+    -- Accumulated note content spans
+    noteContents :: [Automerge.Span]
+  }
+
+type NotesState = State NoteData
+
 toAutomergeBlockType :: ContainerBlockType -> BlockType
 toAutomergeBlockType BulletListItem = Automerge.UnorderedListItemType
 toAutomergeBlockType OrderedListItem = Automerge.OrderedListItemType
 toAutomergeBlockType PandocWriter.BlockQuote = Automerge.BlockQuoteType
 
 writeAutomerge :: (PandocMonad m) => WriterOptions -> Pandoc.Pandoc -> m T.Text
-writeAutomerge _ (Pandoc.Pandoc _ blocks) = pure $ toJSONText $ blocksToAutomergeSpans blocks
+writeAutomerge _ (Pandoc.Pandoc _ blocks) = pure $ toJSONText allSpans
+  where
+    allSpans = mainSpans ++ noteContents notesState
+    (mainSpans, notesState) = runState (blocksToAutomergeSpans [] blocks) initialState
+    initialState = NoteData 0 []
 
-blocksToAutomergeSpans :: [Pandoc.Block] -> [Automerge.Span]
-blocksToAutomergeSpans = concatMap $ blockToAutomergeSpans []
+blocksToAutomergeSpans :: [Automerge.BlockType] -> [Pandoc.Block] -> NotesState [Automerge.Span]
+blocksToAutomergeSpans parentBlockTypes blocks = concat <$> mapM (blockToAutomergeSpans parentBlockTypes) blocks
 
-blockToAutomergeSpans :: [Automerge.BlockType] -> Pandoc.Block -> [Automerge.Span]
+blockToAutomergeSpans :: [Automerge.BlockType] -> Pandoc.Block -> NotesState [Automerge.Span]
 blockToAutomergeSpans parentBlockTypes block = case block of
-  Pandoc.Plain inlines -> Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines
-  Pandoc.Para inlines -> (Automerge.BlockSpan $ AutomergeBlock ParagraphMarker parentBlockTypes False) : (Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  Pandoc.Header level _ inlines -> (Automerge.BlockSpan $ AutomergeBlock (Automerge.HeadingMarker $ Heading $ HeadingLevel level) parentBlockTypes False) : (Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  Pandoc.CodeBlock _ text -> [Automerge.BlockSpan $ AutomergeBlock Automerge.CodeBlockMarker parentBlockTypes False, Automerge.TextSpan $ AutomergeText text []]
-  Pandoc.BulletList items -> concatMap (containerBlockToSpans parentBlockTypes BulletListItem) items
-  Pandoc.OrderedList _ items -> concatMap (containerBlockToSpans parentBlockTypes OrderedListItem) items
-  Pandoc.BlockQuote blocks -> (containerBlockToSpans parentBlockTypes PandocWriter.BlockQuote) blocks
-  _ -> [] -- Ignore blocks we don't recognize. TODO: Implement something more sophisticated here.
+  Pandoc.Plain inlines -> inlinesToAutomergeSpans parentBlockTypes inlines
+  Pandoc.Para inlines -> do
+    inlineSpans <- inlinesToAutomergeSpans parentBlockTypes inlines
+    let blockSpan = Automerge.BlockSpan $ AutomergeBlock ParagraphMarker parentBlockTypes False
+    return $ blockSpan : inlineSpans
+  Pandoc.Header level _ inlines -> do
+    inlineSpans <- inlinesToAutomergeSpans parentBlockTypes inlines
+    let blockSpan = Automerge.BlockSpan $ AutomergeBlock (Automerge.HeadingMarker $ Heading $ HeadingLevel level) parentBlockTypes False
+    return $ blockSpan : inlineSpans
+  Pandoc.CodeBlock _ text ->
+    return
+      [ Automerge.BlockSpan $ AutomergeBlock Automerge.CodeBlockMarker parentBlockTypes False,
+        Automerge.TextSpan $ AutomergeText text []
+      ]
+  Pandoc.BulletList items ->
+    concat <$> mapM (containerBlockToSpans parentBlockTypes BulletListItem) items
+  Pandoc.OrderedList _ items ->
+    concat <$> mapM (containerBlockToSpans parentBlockTypes OrderedListItem) items
+  Pandoc.BlockQuote blocks ->
+    containerBlockToSpans parentBlockTypes PandocWriter.BlockQuote blocks
+  _ -> return [] -- Ignore blocks we don't recognize
 
-containerBlockToSpans :: [Automerge.BlockType] -> ContainerBlockType -> [Pandoc.Block] -> [Automerge.Span]
-containerBlockToSpans parents itemType children = (containerBlockToSpan parents itemType : containerBlockChildrenToSpans parents itemType children)
+containerBlockToSpans :: [Automerge.BlockType] -> ContainerBlockType -> [Pandoc.Block] -> NotesState [Automerge.Span]
+containerBlockToSpans parents itemType children = do
+  let containerSpan = containerBlockToSpan parents itemType
+  childSpans <- containerBlockChildrenToSpans parents itemType children
+  return (containerSpan : childSpans)
   where
     containerBlockToSpan :: [Automerge.BlockType] -> ContainerBlockType -> Automerge.Span
     containerBlockToSpan parentBlockTypes BulletListItem = Automerge.BlockSpan $ AutomergeBlock Automerge.UnorderedListItemMarker parentBlockTypes False
     containerBlockToSpan parentBlockTypes OrderedListItem = Automerge.BlockSpan $ AutomergeBlock Automerge.OrderedListItemMarker parentBlockTypes False
     containerBlockToSpan parentBlockTypes PandocWriter.BlockQuote = Automerge.BlockSpan $ AutomergeBlock Automerge.BlockQuoteMarker parentBlockTypes False
 
-containerBlockChildrenToSpans :: [Automerge.BlockType] -> ContainerBlockType -> [Pandoc.Block] -> [Automerge.Span]
-containerBlockChildrenToSpans parentBlockTypes itemType = concatMap $ blockToAutomergeSpans (parentBlockTypes <> [toAutomergeBlockType itemType])
+containerBlockChildrenToSpans :: [Automerge.BlockType] -> ContainerBlockType -> [Pandoc.Block] -> NotesState [Automerge.Span]
+containerBlockChildrenToSpans parentBlockTypes itemType blocks = concat <$> mapM (blockToAutomergeSpans (parentBlockTypes <> [toAutomergeBlockType itemType])) blocks
 
-inlinesToAutomergeTextSpans :: [Pandoc.Inline] -> [Automerge.TextSpan]
-inlinesToAutomergeTextSpans = mergeSameMarkSpans . foldMap inlineToTextSpan
+inlinesToAutomergeSpans :: [Automerge.BlockType] -> [Pandoc.Inline] -> NotesState [Automerge.Span]
+inlinesToAutomergeSpans parents inlines = mergeSameMarkSpans <$> concat <$> mapM (inlineToAutomergeSpans parents) inlines
 
-mergeSameMarkSpans :: [Automerge.TextSpan] -> [Automerge.TextSpan]
+inlineToAutomergeSpans :: [Automerge.BlockType] -> Pandoc.Inline -> NotesState [Automerge.Span]
+inlineToAutomergeSpans parents inline = case inline of
+  Pandoc.Note noteBlocks -> do
+    -- Generate note ID and create note content
+    state <- get
+    let newNoteId = noteCounter state + 1
+        noteIdText = T.pack $ show newNoteId
+
+    -- Convert note blocks to spans
+    noteSpans <- blocksToAutomergeSpans parents noteBlocks
+    let noteContentSpan = Automerge.BlockSpan $ AutomergeBlock (NoteContentMarker $ Automerge.NoteId noteIdText) [] False
+        allNoteSpans = noteContentSpan : noteSpans
+
+    -- Update state
+    modify $ \s ->
+      s
+        { noteCounter = newNoteId,
+          noteContents = noteContents s ++ allNoteSpans
+        }
+
+    -- Return embedded note reference span
+    return [Automerge.BlockSpan $ AutomergeBlock (NoteRefMarker $ Automerge.NoteId noteIdText) [] True]
+  Pandoc.Strong inlines -> do
+    wrappedSpans <- inlinesToAutomergeSpans parents inlines
+    return $ addMark Automerge.Strong wrappedSpans
+  Pandoc.Emph inlines -> do
+    wrappedSpans <- inlinesToAutomergeSpans parents inlines
+    return $ addMark Automerge.Emphasis wrappedSpans
+  Pandoc.Link _ inlines (linkUrl, linkTitle) -> do
+    wrappedSpans <- inlinesToAutomergeSpans parents inlines
+    return $ addMark (Automerge.LinkMark $ Automerge.Link {url = linkUrl, title = linkTitle}) wrappedSpans
+  _ -> return $ Automerge.TextSpan <$> inlineToTextSpan inline
+
+mergeSameMarkSpans :: [Automerge.Span] -> [Automerge.Span]
 mergeSameMarkSpans = foldr mergeOrAppendAdjacent []
   where
-    -- This is the folding function for merging the adjacent elements if their marks are the same
-    mergeOrAppendAdjacent :: Automerge.TextSpan -> [Automerge.TextSpan] -> [Automerge.TextSpan]
+    mergeOrAppendAdjacent :: Automerge.Span -> [Automerge.Span] -> [Automerge.Span]
     mergeOrAppendAdjacent x [] = [x]
-    -- pattern-match on: the current element (x), the one to its right (firstOfRest) and the rest of the fold
-    mergeOrAppendAdjacent x (firstOfRest : rest) =
-      if marks x == marks firstOfRest
-        -- if the element's marks are the same with the one to its right, we merge them and then add them to the rest of the fold.
-        then (x <> firstOfRest) : rest
-        -- if they are not the same we end up with an extra text span in the list for the current element (we prepend it to the existing list for the fold.)
-        else x : firstOfRest : rest
+    -- We only merge if the adjacent spans are **text** spans and they have the same marks.
+    mergeOrAppendAdjacent (TextSpan xTextSpan) (TextSpan firstOrRestTextSpan : rest)
+      | marks xTextSpan == marks firstOrRestTextSpan =
+          TextSpan (xTextSpan <> firstOrRestTextSpan) : rest
+    mergeOrAppendAdjacent x rest = x : rest
 
 inlineToTextSpan :: Pandoc.Inline -> [Automerge.TextSpan]
 inlineToTextSpan inline = case inline of
   Pandoc.Str str -> [AutomergeText str []]
   Pandoc.Space -> [AutomergeText (T.pack " ") []]
-  Pandoc.Strong inlines -> addMark Automerge.Strong inlines
-  Pandoc.Emph inlines -> addMark Automerge.Emphasis inlines
-  Pandoc.Link _ inlines (linkUrl, linkTitle) -> addMark (Automerge.LinkMark $ Automerge.Link {url = linkUrl, title = linkTitle}) inlines
   Pandoc.Code _ text -> [AutomergeText text [Automerge.Code]]
   -- TODO: Handle other inline elements
   _ -> []
 
-addMark :: Automerge.Mark -> [Pandoc.Inline] -> [Automerge.TextSpan]
--- Monoidally add the mark to all text spans created for the inline elements
-addMark mark inlines = fmap (AutomergeText T.empty [mark] <>) (inlinesToAutomergeTextSpans inlines)
+addMark :: Automerge.Mark -> [Automerge.Span] -> [Automerge.Span]
+addMark mark spans = fmap (addMarkToSpan mark) spans
+  where
+    addMarkToSpan :: Automerge.Mark -> Automerge.Span -> Automerge.Span
+    addMarkToSpan m (Automerge.TextSpan textSpan) = Automerge.TextSpan $ AutomergeText T.empty [m] <> textSpan
+    -- Leave non-text spans (like note refs) unchanged
+    addMarkToSpan _ otherSpan = otherSpan

--- a/test/AutomergeTestUtils.hs
+++ b/test/AutomergeTestUtils.hs
@@ -1,6 +1,6 @@
-module AutomergeTestUtils (paragraphSpan, heading1Span, heading2Span, heading3Span, heading4Span, heading5Span, heading6Span, textSpan, strongTextSpan, emphasisTextSpan, codeTextSpan, textSpanWithMarks, linkTextSpan, codeBlockSpan, blockQuoteSpan, orderedListItemSpan, unorderedListItemSpan) where
+module AutomergeTestUtils (paragraphSpan, heading1Span, heading2Span, heading3Span, heading4Span, heading5Span, heading6Span, textSpan, strongTextSpan, emphasisTextSpan, codeTextSpan, textSpanWithMarks, linkTextSpan, codeBlockSpan, blockQuoteSpan, orderedListItemSpan, unorderedListItemSpan, noteRefSpan, noteContentSpan) where
 
-import Automerge (BlockMarker (..), BlockSpan (..), BlockType (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), Span (..), TextSpan (..))
+import Automerge (BlockMarker (..), BlockSpan (..), BlockType (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), NoteId (..), Span (..), TextSpan (..))
 import qualified Data.Text as T
 
 paragraphSpan :: [BlockType] -> Span
@@ -53,3 +53,9 @@ codeBlockSpan parents = BlockSpan $ AutomergeBlock CodeBlockMarker parents False
 
 blockQuoteSpan :: [BlockType] -> Span
 blockQuoteSpan parents = BlockSpan $ AutomergeBlock BlockQuoteMarker parents False
+
+noteRefSpan :: [BlockType] -> String -> Span
+noteRefSpan parents str = BlockSpan $ AutomergeBlock (NoteRefMarker (NoteId $ T.pack str)) parents True
+
+noteContentSpan :: [BlockType] -> String -> Span
+noteContentSpan parents str = BlockSpan $ AutomergeBlock {blockMarker = (NoteContentMarker (NoteId $ T.pack str)), parentTypes = parents, isEmbed = False}

--- a/test/AutomergeTestUtils.hs
+++ b/test/AutomergeTestUtils.hs
@@ -4,25 +4,25 @@ import Automerge (BlockMarker (..), BlockSpan (..), BlockType (..), Heading (..)
 import qualified Data.Text as T
 
 paragraphSpan :: [BlockType] -> Span
-paragraphSpan parents = BlockSpan $ AutomergeBlock ParagraphMarker parents
+paragraphSpan parents = BlockSpan $ AutomergeBlock ParagraphMarker parents False
 
 heading1Span :: [BlockType] -> Span
-heading1Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 1) parents
+heading1Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 1) parents False
 
 heading2Span :: [BlockType] -> Span
-heading2Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 2) parents
+heading2Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 2) parents False
 
 heading3Span :: [BlockType] -> Span
-heading3Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 3) parents
+heading3Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 3) parents False
 
 heading4Span :: [BlockType] -> Span
-heading4Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 4) parents
+heading4Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 4) parents False
 
 heading5Span :: [BlockType] -> Span
-heading5Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 5) parents
+heading5Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 5) parents False
 
 heading6Span :: [BlockType] -> Span
-heading6Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 6) parents
+heading6Span parents = BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel 6) parents False
 
 textSpan :: String -> Span
 textSpan str = TextSpan $ AutomergeText (T.pack str) []
@@ -43,13 +43,13 @@ textSpanWithMarks :: String -> [Mark] -> Span
 textSpanWithMarks str spanMarks = TextSpan $ AutomergeText (T.pack str) spanMarks
 
 unorderedListItemSpan :: [BlockType] -> Span
-unorderedListItemSpan parents = BlockSpan $ AutomergeBlock UnorderedListItemMarker parents
+unorderedListItemSpan parents = BlockSpan $ AutomergeBlock UnorderedListItemMarker parents False
 
 orderedListItemSpan :: [BlockType] -> Span
-orderedListItemSpan parents = BlockSpan $ AutomergeBlock OrderedListItemMarker parents
+orderedListItemSpan parents = BlockSpan $ AutomergeBlock OrderedListItemMarker parents False
 
 codeBlockSpan :: [BlockType] -> Span
-codeBlockSpan parents = BlockSpan $ AutomergeBlock CodeBlockMarker parents
+codeBlockSpan parents = BlockSpan $ AutomergeBlock CodeBlockMarker parents False
 
 blockQuoteSpan :: [BlockType] -> Span
-blockQuoteSpan parents = BlockSpan $ AutomergeBlock BlockQuoteMarker parents
+blockQuoteSpan parents = BlockSpan $ AutomergeBlock BlockQuoteMarker parents False


### PR DESCRIPTION
This PR add support for Automerge note spans and maps them to Pandoc Notes.

Assumptions:
- In Automerge, we have different spans for note ref and note content
- Note ref is modeled as an [embed](https://automerge.org/docs/reference/under-the-hood/rich_text_schema/#embeds) span